### PR TITLE
Make chip_alarm colours use theme variables

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -232,17 +232,17 @@ chips_alarm:
     icon:
       - color: |
           [[[
-            var alarm_color = "yellow";
+            var alarm_color = "var(--google-yellow)";
             if (entity.state == "armed_home"){
-              var alarm_color = "red";
+              var alarm_color = "var(--google-red)";
             } else if(entity.state == "armed_away"){
-              var alarm_color = "red";
+              var alarm_color = "var(--google-red)";
             } else if(entity.state == "disarmed"){
-              var alarm_color = "green";
+              var alarm_color = "var(--google-green)";
             } else if(entity.state == "arming"){
-              var alarm_color = "orange";
+              var alarm_color = "var(--google-yellow)";
             } else if(entity.state == "triggered"){
-              var alarm_color = "red";
+              var alarm_color = "var(--google-red)";
             }
             return alarm_color;
           ]]]


### PR DESCRIPTION
Generic CSS colours (red/green/orange/yellow) did not match the colour scheme. Updated to use the theme's CSS variables.